### PR TITLE
Add missing parameter in registry.go error handler

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -225,7 +225,7 @@ func getImagesList(w http.ResponseWriter, r *http.Request) (int, string) {
 
 func createTorrentFile(torrentFileName, root, announcePath string) (err error) {
 	var metaInfo *torrent.MetaInfo
-	metaInfo, err = torrent.CreateMetaInfoFromFileSystem(nil, root, 0, false)
+	metaInfo, err = torrent.CreateMetaInfoFromFileSystem(nil, root, "127.0.0.1:8080", 0, false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Added a missing parameter to the torrent.CreateMetaInfoFromFileSystem call (error handler) on line 228

I've built this locally and it works.
